### PR TITLE
Refactor downstream

### DIFF
--- a/src/hep_foundation/pipeline/downstream_model_manager.py
+++ b/src/hep_foundation/pipeline/downstream_model_manager.py
@@ -1,0 +1,311 @@
+import copy
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+import tensorflow as tf
+
+from hep_foundation.config.logging_config import get_logger
+from hep_foundation.models.base_model import CustomKerasModelWrapper
+from hep_foundation.models.dnn_predictor import DNNPredictorConfig
+from hep_foundation.models.model_factory import ModelFactory
+from hep_foundation.training.model_trainer import ModelTrainer
+
+
+class DownstreamModelType(Enum):
+    """Types of downstream models that can be created."""
+
+    FROM_SCRATCH = "from_scratch"
+    FINE_TUNED = "fine_tuned"
+    FIXED_ENCODER = "fixed_encoder"
+
+
+class DownstreamModelManager:
+    """
+    Manages creation and training of downstream models for foundation model evaluation.
+
+    This class provides shared functionality for both regression and signal classification
+    evaluation tasks, reducing code duplication and improving maintainability.
+    """
+
+    def __init__(self, logger=None):
+        """
+        Initialize the downstream model manager.
+
+        Args:
+            logger: Logger instance (optional, will create one if not provided)
+        """
+        self.logger = logger or get_logger(__name__)
+
+    def create_subset_dataset(
+        self,
+        dataset: tf.data.Dataset,
+        num_events: int,
+        batch_size: int,
+        data_size_index: Optional[int] = None,
+    ) -> tf.data.Dataset:
+        """
+        Create a subset of the dataset with exactly num_events events.
+
+        Args:
+            dataset: The full dataset to subset
+            num_events: Number of events to include in the subset
+            batch_size: Batch size for the resulting dataset
+            data_size_index: Index for seeding (ensures different subsets for different sizes)
+
+        Returns:
+            Subset dataset with the specified number of events
+        """
+        # Convert to unbatched dataset to count events precisely
+        unbatched = dataset.unbatch()
+        # Use different seed for each data size to ensure independent sampling
+        # This prevents smaller datasets from being strict subsets of larger ones
+        seed = 42 + (data_size_index or 0)
+        shuffled = unbatched.shuffle(buffer_size=50000, seed=seed)
+        subset = shuffled.take(num_events)
+        # Rebatch with original batch size
+        return subset.batch(batch_size)
+
+    def build_model_head(
+        self,
+        dnn_model_config: DNNPredictorConfig,
+        input_dim: int,
+        output_shape: tuple[int, ...],
+        output_activation: Optional[str] = None,
+        name_suffix: str = "",
+    ) -> tf.keras.Model:
+        """
+        Build a model head (regressor or classifier) with specified architecture.
+
+        Args:
+            dnn_model_config: Base DNN configuration to modify
+            input_dim: Input dimension (latent space size)
+            output_shape: Output shape for the head
+            output_activation: Output activation function (e.g., 'sigmoid' for classification)
+            name_suffix: Suffix to add to the model name
+
+        Returns:
+            Keras model for the head
+        """
+        # Create a copy of the DNN config with modified architecture
+        head_config = copy.deepcopy(dnn_model_config)
+
+        # Update the architecture for the head
+        architecture_updates = {
+            "input_shape": (input_dim,),
+            "output_shape": output_shape,
+            "name": f"{dnn_model_config.architecture.get('name', 'head')}_{name_suffix}",
+        }
+
+        if output_activation is not None:
+            architecture_updates["output_activation"] = output_activation
+
+        head_config.architecture.update(architecture_updates)
+
+        head_model_wrapper = ModelFactory.create_model(
+            model_type="dnn_predictor", config=head_config
+        )
+        head_model_wrapper.build()
+        return head_model_wrapper.model
+
+    def create_downstream_model(
+        self,
+        model_type: DownstreamModelType,
+        input_shape: tuple[int, ...],
+        output_shape: tuple[int, ...],
+        pretrained_encoder: Optional[tf.keras.Model],
+        encoder_hidden_layers: list[int],
+        latent_dim: int,
+        dnn_model_config: DNNPredictorConfig,
+        encoder_activation: str = "relu",
+        output_activation: Optional[str] = None,
+    ) -> tf.keras.Model:
+        """
+        Create a downstream model of the specified type.
+
+        Args:
+            model_type: Type of model to create (FROM_SCRATCH, FINE_TUNED, or FIXED_ENCODER)
+            input_shape: Input shape for the model
+            output_shape: Output shape for the model
+            pretrained_encoder: Pre-trained encoder (required for FINE_TUNED and FIXED_ENCODER)
+            encoder_hidden_layers: List of hidden layer sizes for the encoder
+            latent_dim: Latent space dimension
+            dnn_model_config: Configuration for the DNN head
+            encoder_activation: Activation function for encoder layers
+            output_activation: Output activation function (e.g., 'sigmoid' for classification)
+
+        Returns:
+            Complete downstream model
+        """
+        model_inputs = tf.keras.Input(
+            shape=input_shape, name=f"input_features_{model_type.value}"
+        )
+
+        if model_type == DownstreamModelType.FROM_SCRATCH:
+            # Build encoder from scratch
+            encoder_layers = []
+            for units in encoder_hidden_layers:
+                encoder_layers.append(
+                    tf.keras.layers.Dense(units, activation=encoder_activation)
+                )
+            encoder_layers.append(
+                tf.keras.layers.Dense(latent_dim, name="scratch_latent_space")
+            )
+
+            encoder_part = tf.keras.Sequential(encoder_layers, name="scratch_encoder")
+            encoded = encoder_part(model_inputs)
+
+        elif model_type == DownstreamModelType.FINE_TUNED:
+            if pretrained_encoder is None:
+                raise ValueError("Pretrained encoder is required for fine-tuned models")
+
+            # Use pretrained encoder with training enabled
+            encoded = pretrained_encoder(model_inputs)
+
+            # Add dtype casting to ensure compatibility with QKeras layers
+            encoded = tf.keras.layers.Lambda(
+                lambda x: tf.cast(x, tf.float32), name=f"dtype_cast_{model_type.value}"
+            )(encoded)
+
+            # Create encoder wrapper to control trainability
+            encoder_part = tf.keras.Model(
+                inputs=model_inputs,
+                outputs=encoded,
+                name=f"{model_type.value}_pretrained_encoder",
+            )
+            encoder_part.trainable = True
+            encoded = encoder_part(model_inputs)
+
+        elif model_type == DownstreamModelType.FIXED_ENCODER:
+            if pretrained_encoder is None:
+                raise ValueError(
+                    "Pretrained encoder is required for fixed encoder models"
+                )
+
+            # Use pretrained encoder with training disabled
+            encoded = pretrained_encoder(model_inputs)
+
+            # Add dtype casting to ensure compatibility with QKeras layers
+            encoded = tf.keras.layers.Lambda(
+                lambda x: tf.cast(x, tf.float32), name=f"dtype_cast_{model_type.value}"
+            )(encoded)
+
+            # Create encoder wrapper to control trainability
+            encoder_part = tf.keras.Model(
+                inputs=model_inputs,
+                outputs=encoded,
+                name=f"{model_type.value}_pretrained_encoder",
+            )
+            encoder_part.trainable = False
+            encoded = encoder_part(model_inputs)
+
+        else:
+            raise ValueError(f"Unknown model type: {model_type}")
+
+        # Build the task-specific head
+        head_model = self.build_model_head(
+            dnn_model_config=dnn_model_config,
+            input_dim=latent_dim,
+            output_shape=output_shape,
+            output_activation=output_activation,
+            name_suffix=model_type.value,
+        )
+
+        # Connect encoder and head
+        predictions = head_model(encoded)
+
+        # Create the complete model
+        task_name = "Classifier" if output_activation == "sigmoid" else "Regressor"
+        model_name = f"{task_name}_{model_type.value.replace('_', ' ').title().replace(' ', '_')}"
+
+        complete_model = tf.keras.Model(
+            inputs=model_inputs,
+            outputs=predictions,
+            name=model_name,
+        )
+
+        return complete_model
+
+    def train_and_evaluate_model(
+        self,
+        model: tf.keras.Model,
+        model_name: str,
+        train_dataset: tf.data.Dataset,
+        val_dataset: tf.data.Dataset,
+        test_dataset: tf.data.Dataset,
+        training_config: dict[str, Any],
+        fixed_epochs: int,
+        data_size: int,
+        output_dir: Path,
+        save_training_history: bool = False,
+        verbose_training: str = "minimal",
+        return_accuracy: bool = False,
+    ) -> tuple[float, ...]:
+        """
+        Train and evaluate a downstream model.
+
+        Args:
+            model: Keras model to train
+            model_name: Name for the model (used in logging and file naming)
+            train_dataset: Training dataset
+            val_dataset: Validation dataset
+            test_dataset: Test dataset
+            training_config: Training configuration dictionary
+            fixed_epochs: Number of epochs to train for
+            data_size: Size of training data (for logging)
+            output_dir: Directory to save training histories
+            save_training_history: Whether to save training history
+            verbose_training: Verbosity level for training
+            return_accuracy: Whether to return accuracy metric (for classification)
+
+        Returns:
+            Tuple of (test_loss,) for regression or (test_loss, test_accuracy) for classification
+        """
+        self.logger.info(f"Training {model_name} model with {data_size} events...")
+
+        # Wrap the Keras model with CustomKerasModelWrapper for ModelTrainer
+        wrapped_model = CustomKerasModelWrapper(model, name=model_name)
+
+        # Prepare training config with fixed epochs
+        trainer_config = {
+            "batch_size": training_config.get("batch_size", 32),
+            "epochs": fixed_epochs,
+            "learning_rate": training_config.get("learning_rate", 0.001),
+            "early_stopping": {
+                "patience": fixed_epochs + 1,  # Disable early stopping
+                "min_delta": 0,
+            },
+        }
+
+        trainer = ModelTrainer(model=wrapped_model, training_config=trainer_config)
+
+        # Train the model
+        _ = trainer.train(
+            dataset=train_dataset,
+            validation_data=val_dataset,
+            callbacks=[],  # No callbacks for speed
+            training_history_dir=output_dir / "training_histories"
+            if save_training_history
+            else None,
+            model_name=model_name,
+            dataset_id=f"downstream_eval_{data_size}",
+            experiment_id="downstream_evaluation",
+            verbose_training=verbose_training,
+            save_individual_history=True,  # Save individual files for comparison plots
+        )
+
+        # Evaluate on test set
+        test_metrics = trainer.evaluate(test_dataset)
+        test_loss = test_metrics.get("test_loss", test_metrics.get("test_mse", 0.0))
+
+        if return_accuracy:
+            test_accuracy = test_metrics.get("test_binary_accuracy", 0.0)
+            self.logger.info(
+                f"{model_name} with {data_size} events - Test Loss: {test_loss:.6f}, Test Accuracy: {test_accuracy:.6f}"
+            )
+            return test_loss, test_accuracy
+        else:
+            self.logger.info(
+                f"{model_name} with {data_size} events - Test Loss: {test_loss:.6f}"
+            )
+            return (test_loss,)

--- a/src/hep_foundation/pipeline/downstream_model_manager.py
+++ b/src/hep_foundation/pipeline/downstream_model_manager.py
@@ -296,10 +296,28 @@ class DownstreamModelManager:
 
         # Evaluate on test set
         test_metrics = trainer.evaluate(test_dataset)
-        test_loss = test_metrics.get("test_loss", test_metrics.get("test_mse", 0.0))
+
+        # Extract test loss - try common metric names, raise error if not found
+        if "test_loss" in test_metrics:
+            test_loss = test_metrics["test_loss"]
+        elif "test_mse" in test_metrics:
+            test_loss = test_metrics["test_mse"]
+        else:
+            available_metrics = list(test_metrics.keys())
+            raise ValueError(
+                f"Expected metric 'test_loss' or 'test_mse' not found in evaluation results. "
+                f"Available metrics: {available_metrics}"
+            )
 
         if return_accuracy:
-            test_accuracy = test_metrics.get("test_binary_accuracy", 0.0)
+            # Extract test accuracy - raise error if not found for classification tasks
+            if "test_binary_accuracy" not in test_metrics:
+                available_metrics = list(test_metrics.keys())
+                raise ValueError(
+                    f"Expected metric 'test_binary_accuracy' not found in evaluation results. "
+                    f"Available metrics: {available_metrics}"
+                )
+            test_accuracy = test_metrics["test_binary_accuracy"]
             self.logger.info(
                 f"{model_name} with {data_size} events - Test Loss: {test_loss:.6f}, Test Accuracy: {test_accuracy:.6f}"
             )

--- a/tests/_test_pipeline_config.yaml
+++ b/tests/_test_pipeline_config.yaml
@@ -10,8 +10,8 @@ dataset:
   run_numbers: ["00298967", "00311481"]  # Just 2 runs for speed
   signal_keys: ["zprime_tt", "wprime_taunu"]  # 2 signals for testing (removed "DMA", "leptoquark", "dm_4top_scalar")
   catalog_limit: 2  # Very small for testing
-  event_limit: 2000  # Limit events per catalog for faster testing
-  signal_event_limit: 5000  # Higher limit for signal data to allow full sample collection
+  event_limit: 200  # Limit events per catalog for faster testing
+  signal_event_limit: 500  # Higher limit for signal data to allow full sample collection
   validation_fraction: 0.1
   test_fraction: 0.1
   shuffle_buffer: 100  # Small buffer
@@ -117,8 +117,8 @@ training:
 
 # Evaluation Settings - minimal for testing
 evaluation:
-  regression_data_sizes: [500, 1000]  # Small sizes for testing
-  signal_classification_data_sizes: [500, 1000]  # Small sizes for testing
+  regression_data_sizes: [100, 500, 1000]  # Small sizes for testing
+  signal_classification_data_sizes: [100, 500, 1000]  # Small sizes for testing
   fixed_epochs: 3  # Very few epochs for testing
 
 # Pipeline Settings - test-specific paths


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Centralized downstream model creation, training, and evaluation into a new DownstreamModelManager and updated both regression and signal classification evaluators to use it. This removes duplicated logic, standardizes experiments across tasks, and speeds up tests.

- **Refactors**
  - Added DownstreamModelManager with:
    - create_subset_dataset for deterministic, size-specific sampling and rebatching.
    - create_downstream_model supporting FROM_SCRATCH, FINE_TUNED, and FIXED_ENCODER (with dtype casts for QKeras).
    - train_and_evaluate_model with fixed epochs, disabled early stopping, optional accuracy, and training history saving.
  - Rewrote RegressionEvaluator and SignalClassificationEvaluator to use the manager, simplifying model setup and training loops.
  - Standardized data-efficiency runs and results collection across tasks; regression keeps prediction/difference histogram outputs.
  - Removed ad-hoc dataset loading/testing code in regression; now uses load_atlas_datasets.
  - Test config: reduced event limits and added smaller data sizes (100, 500, 1000) to speed CI; fixed_epochs=3.

<!-- End of auto-generated description by cubic. -->

